### PR TITLE
Specify minimum Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "description": "pluto.tv to XMLTV & M3U converter",
   "main": "index.js",
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
     "fs-extra": "^9.0.0",
     "jsontoxml": "^1.0.1",


### PR DESCRIPTION
As mentioned in #1, Node version 10 or greater is required.