### PR TITLE
Fixed Xteve mapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ plutoIPTV.grabJSON(function (err, channels) {
 
       m3u8 =
         m3u8 +
-        `#EXTINF:0 channel-id="${slug}" tvg-logo="${logo}" group-title="${group}", ${name}
+        `#EXTINF:0 tvg-id="${slug}" tvg-logo="${logo}" group-title="${group}", ${name}
 ${m3uUrl}
 
 `;

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ plutoIPTV.grabJSON(function (err, channels) {
       m3uUrl = m3uUrl.toString();
 
       let slug = channel.slug;
-      let logo = channel.solidLogoPNG.path;
+      let logo = channel.colorLogoPNG.path;
       let group = channel.category;
       let name = channel.name;
 
@@ -142,7 +142,7 @@ ${m3uUrl}
           { name: 'display-name', text: channel.name },
           { name: 'display-name', text: channel.number },
           { name: 'desc', text: channel.summary },
-          { name: 'icon', attrs: { src: channel.solidLogoPNG.path } },
+          { name: 'icon', attrs: { src: channel.colorLogoPNG.path } },
         ],
       });
 


### PR DESCRIPTION
From Xteve documentation:

The mapping function allows you to edit the channels from the playlists.
Only active channels (green) are passed to Plex, Emby and the xteve.m3u playlist. For a channel to be active, it must be assigned to an XMLTV channel. New channels e.g. new filter rules automatically assign an XMLTV file if the IDs from the M3U and XMLTV file match.

    tvg-id (M3U) == channel id (XMLTV)

As you can see xteve requires the tvg-id tag as opposed to the channel-id tag in the m3u8 file. Changing this one line seems to fix it and allows xteve to automatically map the channels. Not sure what kind of impact it would have on other IPTV clients however.
