### PR TITLE
move channel output after programmes

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,17 +135,6 @@ ${m3uUrl}
   //////////////
   channels.forEach((channel) => {
     if (channel.isStitched) {
-      tv.push({
-        name: 'channel',
-        attrs: { id: channel.slug },
-        children: [
-          { name: 'display-name', text: channel.name },
-          { name: 'display-name', text: channel.number },
-          { name: 'desc', text: channel.summary },
-          { name: 'icon', attrs: { src: channel.colorLogoPNG.path } },
-        ],
-      });
-
       //////////////
       // Episodes //
       //////////////
@@ -219,6 +208,17 @@ ${m3uUrl}
         });
       }
     }
+
+    tv.push({
+      name: 'channel',
+      attrs: { id: channel.slug },
+      children: [
+        { name: 'display-name', text: channel.name },
+        { name: 'display-name', text: channel.number },
+        { name: 'desc', text: channel.summary },
+        { name: 'icon', attrs: { src: channel.colorLogoPNG.path } },
+      ],
+    });
   });
 
   let epg = j2x(


### PR DESCRIPTION
If a `<channel>` is the first tag AND it has a `<desc>` tag WITH content it will break the npm `xmltv` package.

Very strange behaviour but that pckage is not maintained and used in several projects.